### PR TITLE
fix industry FE fixing year (2025 instead of 2020)

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1202940'
+ValidationKey: '1223233'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrindustry: input data generation for the REMIND industry module'
-version: 0.6.0
-date-released: '2024-11-22'
+version: 0.6.1
+date-released: '2024-11-26'
 abstract: The mrindustry packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrindustry
 Title: input data generation for the REMIND industry module
-Version: 0.6.0
-Date: 2024-11-22
+Version: 0.6.1
+Date: 2024-11-26
 Authors@R: c(
     person(given = "Falk", family = "Benke", email = "benke@pik-potsdam.de",
            role = c("aut", "cre")),

--- a/R/calcFeDemandIndustry.R
+++ b/R/calcFeDemandIndustry.R
@@ -421,7 +421,8 @@ calcFeDemandIndustry <- function(use_ODYM_RECC = FALSE,
 
   fixing_year <- calcOutput(
     type = 'industry_subsectors_specific', subtype = 'fixing_year',
-    scenarios = getNames(remind, fulldim = TRUE)[['scenario']],
+    scenarios = c(getNames(remind, fulldim = TRUE)[['scenario']],
+                  'gdp_SSP2_highDemDEU'),
     regions = unique(region_mapping_21$region),
     aggregate = FALSE
   ) %>%

--- a/R/calcFeDemandIndustry.R
+++ b/R/calcFeDemandIndustry.R
@@ -1486,46 +1486,17 @@ calcFeDemandIndustry <- function(use_ODYM_RECC = FALSE,
     )
   }
 
-  # decrease values by alpha p.a.
-  decrease_specific_energy_by_alpha <- function(df,
-                                                year = NULL,
-                                                exclude_scenario = FALSE)
-  {
-    df %>%
-      group_by(!!!syms(c("scenario", "region", "subsector"))) %>%
-      arrange(.data$year) %>%
-      mutate(
-        fixing_year = ifelse(!is.null(.env$year), .env$year, .data$fixing_year),
-        specific.energy = case_when(
-          exclude_scenario == .data$scenario ~ .data$specific.energy,
-          'absolute' == .data$type ~
-            ( (.data$specific.energy - .data$limit)
-            * pmin(1, (1 - .data$alpha) ^ (.data$year - .data$fixing_year))
-            )
-          + .data$limit,
-          'relative' == .data$type ~
-            ( .data$specific.energy * (1 - .data$limit)
-            * pmin(1, (1 - .data$alpha) ^ (.data$year - .data$fixing_year))
-            )
-          + (.data$specific.energy * .data$limit),
-          TRUE ~ NA)) %>%
-      assert(not_na, everything()) %>%
-      ungroup()
-  }
-
-  industry_subsectors_specific_energy <-
-    industry_subsectors_specific_energy %>%
-    # default scenario values are calculated from the last year of empirical
-    # data on
+  #### decrease values by alpha p.a. ----
+  industry_subsectors_specific_energy <- industry_subsectors_specific_energy %>%
+    # calculate default scenario values first
     filter('gdp_SSP2' == .data$scenario) %>% # TODO: define default scenario
-    select(-'scenario') %>%
+    left_join(fixing_year, c('scenario', 'region')) %>%
     inner_join(
       industry_subsectors_specific_FE,
 
-      by = c("region", "subsector"),
-      relationship = 'many-to-many' # rhs: many years, lhs: many scenarios
+      c('scenario', 'region', 'subsector')
     ) %>%
-    inner_join(specific_FE_limits, "subsector") %>%
+    inner_join(specific_FE_limits, 'subsector') %>%
     # allow for year-specific decreases
     interpolate_missing_periods_(
       periods = list(
@@ -1534,11 +1505,57 @@ calcFeDemandIndustry <- function(use_ODYM_RECC = FALSE,
                                max(fixing_year$fixing_year)))),
       value = 'specific.energy',
       method = 'linear') %>%
-    left_join(fixing_year, by = c('scenario', 'region')) %>%
-    assert(not_na, 'fixing_year',
-           description = 'missing fixing_year for scenario in specific_FE') %>%
-    decrease_specific_energy_by_alpha(year = last_empirical_year) %>%
-    select("scenario", "region", "year", "subsector", "specific.energy")
+    mutate(
+      specific.energy = case_when(
+        'absolute' == .data$type ~
+            ( (.data$specific.energy - .data$limit)
+            * pmin(1, (1 - .data$alpha) ^ (.data$year - .env$last_empirical_year))
+            )
+          + .data$limit,
+
+        'relative' == .data$type ~
+            ( .data$specific.energy * (1 - .data$limit)
+            * pmin(1, (1 - .data$alpha) ^ (.data$year - .env$last_empirical_year))
+            )
+          + (.data$specific.energy * .data$limit),
+        TRUE ~ NA)) %>%
+    assert(not_na, everything()) %>%
+    ungroup() %>%
+    # extend to non-standard scenarios
+    select(-'fixing_year', -'alpha', -'scenario') %>%
+    left_join(fixing_year, 'region', relationship = 'many-to-many') %>%
+    inner_join(
+      industry_subsectors_specific_FE,
+
+      c('scenario', 'region', 'subsector')
+    ) %>%
+    group_by(.data$region, .data$subsector) %>%
+    mutate(
+      # continue default scenario data until fixing year
+      specific.energy = ifelse(
+        # TODO: define default scenario
+        'gdp_SSP2' != .data$scenario & .data$fixing_year < .data$year,
+        .data$specific.energy[.data$fixing_year == .data$year],
+        .data$specific.energy),
+      specific.energy = case_when(
+        # TODO: define default scenario
+        'gdp_SSP2' == .data$scenario ~ .data$specific.energy,
+
+        'absolute' == .data$type ~
+          ( (.data$specific.energy - .data$limit)
+            * pmin(1,  (1 - .data$alpha) ^ (.data$year - .data$fixing_year))
+          )
+        + .data$limit,
+
+        'relative' == .data$type ~
+          ( .data$specific.energy * (1 - .data$limit)
+            * pmin(1, (1 - .data$alpha) ^ (.data$year - .data$fixing_year))
+          )
+        + (.data$specific.energy * .data$limit),
+        TRUE ~ NA)) %>%
+    assert(not_na, everything()) %>%
+    ungroup() %>%
+    select('scenario', 'region', 'year', 'subsector', 'specific.energy')
 
   ### converge subsector en shares to global value ----
   # calculate global shares, weighted by subsector activity

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # input data generation for the REMIND industry module
 
-R package **mrindustry**, version **0.6.0**
+R package **mrindustry**, version **0.6.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrindustry)](https://cran.r-project.org/package=mrindustry)  [![R build status](https://github.com/pik-piam/mrindustry/workflows/check/badge.svg)](https://github.com/pik-piam/mrindustry/actions) [![codecov](https://codecov.io/gh/pik-piam/mrindustry/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrindustry) [![r-universe](https://pik-piam.r-universe.dev/badges/mrindustry)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **mrindustry** in publications use:
 
-Benke F, Dürrwächter J, Rodrigues R, Moreno-Leiva S, Baumstark L, Pehl M (2024). _mrindustry: input data generation for the REMIND industry module_. R package version 0.6.0, <https://github.com/pik-piam/mrindustry>.
+Benke F, Dürrwächter J, Rodrigues R, Moreno-Leiva S, Baumstark L, Pehl M (2024). _mrindustry: input data generation for the REMIND industry module_. R package version 0.6.1, <https://github.com/pik-piam/mrindustry>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrindustry: input data generation for the REMIND industry module},
   author = {Falk Benke and Jakob Dürrwächter and Renato Rodrigues and Simón Moreno-Leiva and Lavinia Baumstark and Michaja Pehl},
   year = {2024},
-  note = {R package version 0.6.0},
+  note = {R package version 0.6.1},
   url = {https://github.com/pik-piam/mrindustry},
 }
 ```


### PR DESCRIPTION
SSP2 specific energy demand is calculated from the last year of empirical data (2020) onwards.  Then all other scenarios' specific energy demand is calculated based on SSP2 specific energy demand after their respective fixing year (2028 for SSP1, 2025 for all others).