### PR TITLE
Implement explicit scenario choice across package (clean version).

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3041140'
+ValidationKey: '3222400'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrindustry: input data generation for the REMIND industry module'
-version: 0.15.1
+version: 0.16.0
 date-released: '2025-02-21'
 abstract: The mrindustry packages contains data preprocessing for the REMIND model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrindustry
 Title: input data generation for the REMIND industry module
-Version: 0.15.1
+Version: 0.16.0
 Date: 2025-02-21
 Authors@R: c(
     person(given = "Falk", family = "Benke", email = "benke@pik-potsdam.de",

--- a/R/calcFeDemandIndustry.R
+++ b/R/calcFeDemandIndustry.R
@@ -5,6 +5,8 @@
 #'   to `FALSE`.)
 #' @param last_empirical_year Last year for which empirical data is available.
 #'   Defaults to 2020.
+#' @param scenarios Vector of strings designating the scenario. !!Currently it acts as a filter only, with the actual
+#'  scenarios computed within the function hard-coded into remind_scenarios.
 #' @importFrom assertr assert not_na verify
 #' @importFrom dplyr anti_join arrange as_tibble between bind_rows case_when
 #'   distinct filter first full_join group_by inner_join left_join
@@ -21,10 +23,32 @@
 #' @importFrom tidyselect all_of
 #' @author Michaja Pehl
 #'
-calcFeDemandIndustry <- function(use_ODYM_RECC = FALSE, last_empirical_year = 2020) {
+calcFeDemandIndustry <- function(scenarios, use_ODYM_RECC = FALSE, last_empirical_year = 2020) {
+
+  # The scenarios argument is currently only used to filter at the end.
+  ## Replace any calls to scenario groups such as "SSPs" and "SSP2IndiaDEAs", with calls to the individual scenarios.
+  scenarios <- mrdrivers::toolReplaceShortcuts(scenarios)
+
+  # Will ideally be replaced by direct usage of the "scenario" argument in the future. SSP2_NAV_all not included here
+  # on purpose (is only created by duplication of SSP2 at the end).
+  remind_scenarios <- c(
+    paste0("SSP", c(1:5, "2_lowEn", "2_highDemDEU", "2IndiaHigh", "2IndiaMedium")),
+    paste0("SDP", c("", "_EI", "_RC", "_MC"))
+  )
+
+  # Check if all the scenarios are available.
+  if (!all(scenarios %in% c(remind_scenarios, "SSP2_NAV_all"))) {
+    stop(paste("The",
+               paste(scenarios[! scenarios %in% c(remind_scenarios, "SSP2_NAV_all")], collapse = ", "),
+               "scenario(s) are not available."))
+  }
+
+  gdpPopScen <- remind_scenarios[
+    remind_scenarios %in% mrdrivers::toolGetScenarioDefinition(driver = "GDPpc", aslist = TRUE)$scenario
+  ]
 
   # ---- Industry subsectors data and FE stubs ----
-  stationary <- readSource("Stationary")[, , c("feindheat", "feh2i")]
+  stationary <- readSource("Stationary", subset = remind_scenarios)[, , c("feindheat", "feh2i")]
 
   # aggregate to 5-year averages to suppress volatility
   stationary <- mrremind::toolAggregateTimeSteps(stationary)
@@ -148,11 +172,6 @@ calcFeDemandIndustry <- function(use_ODYM_RECC = FALSE, last_empirical_year = 20
     remind[, , getNames(tmp)] <- tmp
   }
 
-  remind_scenarios <- c(
-    paste0("SSP", c(1:5, "2_lowEn", "2_highDemDEU")),
-    paste0("SDP", c("", "_EI", "_RC", "_MC"))
-  )
-
   remind_years <- seq(1995, 2150, 5)
 
   # ---- Industry subsectors data and FE stubs ----
@@ -174,6 +193,7 @@ calcFeDemandIndustry <- function(use_ODYM_RECC = FALSE, last_empirical_year = 20
   industry_subsectors_ue <- mbind(
     calcOutput(
       type = "Industry_Value_Added",
+      scenario = gdpPopScen,
       match.steel.historic.values = TRUE,
       match.steel.estimates = "IEA_ETP",
       China_Production = readSource(type = "ExpertGuess",
@@ -182,13 +202,12 @@ calcFeDemandIndustry <- function(use_ODYM_RECC = FALSE, last_empirical_year = 20
         madrat_mule(),
       aggregate = FALSE,
       years = sort(union(remind_years, last_empirical_year:max(fixing_year$fixing_year))),
-      supplementary = FALSE,
       warnNA = FALSE
     ),
-
     calcOutput(
       type = "Steel_Projections",
       subtype = "production",
+      scenario = gdpPopScen,
       match.steel.historic.values = TRUE,
       match.steel.estimates = "IEA_ETP",
       China_Production = readSource(type = "ExpertGuess",
@@ -202,21 +221,14 @@ calcFeDemandIndustry <- function(use_ODYM_RECC = FALSE, last_empirical_year = 20
   )
 
   ## re-curve specific industry activity per unit GDP ----
-  GDP <- calcOutput(
-    type = "GDP",
-    scenario = c("SSPs", "SDPs"),
-    naming = "scenario",
-    average2020 = FALSE,
-    years = sort(union(remind_years,
-                       last_empirical_year:max(fixing_year$fixing_year))),
-    aggregate = FALSE,
-    supplementary = FALSE) %>%
-    as.data.frame() %>%
+  GDP <- calcOutput("GDP",
+                    scenario = gdpPopScen,
+                    average2020 = FALSE,
+                    years = sort(union(remind_years, last_empirical_year:max(fixing_year$fixing_year))),
+                    aggregate = FALSE) %>%
     as_tibble() %>%
-    select(iso3c = "Region", year = "Year", scenario = "Data1",
-           GDP = "Value") %>%
-    character.data.frame() %>%
-    mutate(year = as.integer(.data$year))
+    dplyr::rename("scenario" = "variable", "GDP" = "value") %>%
+    dplyr::mutate(dplyr::across(tidyselect::where(is.factor), as.character))
 
   ### calculate specific material demand factors ----
   foo <- full_join(
@@ -571,11 +583,7 @@ calcFeDemandIndustry <- function(use_ODYM_RECC = FALSE, last_empirical_year = 20
         ) %>%
         select(-"scenario", -"GDP", -"year") %>%
         inner_join(
-          calcOutput(type = "Population",
-                     scenario = c("SSPs", "SDPs"),
-                     naming = "scenario",
-                     aggregate = FALSE,
-                     years = remind_years) %>%
+          calcOutput("Population", scenario = gdpPopScen, aggregate = FALSE, years = remind_years) %>%
             magclass_to_tibble() %>%
             select("iso3c", "scenario" = "variable", "year", "population" = "value") %>%
             filter(
@@ -1419,18 +1427,17 @@ calcFeDemandIndustry <- function(use_ODYM_RECC = FALSE, last_empirical_year = 20
     industry_subsectors_en[,remind_years,],
     industry_subsectors_ue[,remind_years,])
 
+  # Add SSP2_NAV_all as duplicate of SSP2, if required.
+  if ("SSP2_NAV_all" %in% scenarios) remind <- mbind(remind, setItems(remind[, , "SSP2"], 3.1, "SSP2_NAV_all"))
+  # Filter by scenario
+  remind <-  mselect(remind, scenario = scenarios)
+
   # ---- _ prepare output ----
-
-  return(list(
-    x = remind,
-    weight = NULL,
-    unit = paste0(
-      "EJ, except ue_cement (Gt), ue_primary_steel and ",
-      "ue_secondary_steel (Gt) and ue_chemicals and ",
-      "ue_otherInd ($tn)"
-    ),
-    description = "demand pathways for final energy demand in industry",
-    structure.data = "^(SSP[1-5].*|SDP.*)\\.(fe|ue)"
-  ))
-
+  list(x = remind,
+       weight = NULL,
+       unit = paste0("EJ, except ue_cement (Gt), ue_primary_steel and ",
+                     "ue_secondary_steel (Gt) and ue_chemicals and ",
+                     "ue_otherInd ($tn)"),
+       description = "demand pathways for final energy demand in industry",
+       structure.data = "^(SSP[1-5].*|SDP.*)\\.(fe|ue)")
 }

--- a/R/calcFeDemandIndustry.R
+++ b/R/calcFeDemandIndustry.R
@@ -207,7 +207,7 @@ calcFeDemandIndustry <- function(scenarios, use_ODYM_RECC = FALSE, last_empirica
     calcOutput(
       type = "Steel_Projections",
       subtype = "production",
-      scenario = gdpPopScen,
+      scenarios = gdpPopScen,
       match.steel.historic.values = TRUE,
       match.steel.estimates = "IEA_ETP",
       China_Production = readSource(type = "ExpertGuess",

--- a/R/calcIndustry_CCS_limits.R
+++ b/R/calcIndustry_CCS_limits.R
@@ -38,6 +38,7 @@
 #' first years, and by the annual growth factor `a2` afterwards (defaulting to
 #' 70 % and 20 %, respectively).
 #'
+#' @param scenarios Vector of strings designating the FEdemand scenarios.
 #' @param a1,a2 Annual growth factors of CCS capacity limits, for the first ten
 #'     years and thereafter, default to `0.7` and `0.2` (70 % and 20 %,
 #'     respectively).
@@ -65,6 +66,7 @@
 #'
 #' @export
 calcIndustry_CCS_limits <- function(
+    scenarios,
     a1 = 0.3, a2 = 0.15,
     installation_minimum = 1,
     stage_weight = c('Operational'          = 1,
@@ -87,7 +89,11 @@ calcIndustry_CCS_limits <- function(
   remind_timesteps <- unique(quitte::remind_timesteps$period)
 
   ## read SSP2 industry activity ----
-  ind_activity <- calcOutput('FEdemand', aggregate = FALSE, years = remind_timesteps) %>%
+  ### Pass the scenarios argument to FEdemand to optimize madrat caching.
+  ind_activity <- calcOutput("FEdemand",
+                             scenario = unique(c(scenarios, "SSP2")),
+                             aggregate = FALSE,
+                             years = remind_timesteps) %>%
     `[`(,,paste0('SSP2.', c('ue_cement', 'ue_chemicals', 'ue_steel_primary'))) %>%
     magclass_to_tibble() %>%
     mutate(subsector = sub('ue_([^_]+).*', '\\1', .data$item), .keep = 'unused') %>%

--- a/R/calcIndustry_EEK.R
+++ b/R/calcIndustry_EEK.R
@@ -28,7 +28,7 @@ calcIndustry_EEK <- function(kap, scenarios) {
   industry_VA <- calcOutput(
     type = 'Industry_Value_Added',
     subtype = 'economic',
-    scenario = unique(c(scenarios, "SSP2")),
+    scenarios = unique(c(mrdrivers::toolReplaceShortcuts(scenarios), "SSP2")),
     match.steel.historic.values = TRUE,
     match.steel.estimates = 'IEA_ETP',
     China_Production = readSource(type = 'ExpertGuess',

--- a/R/calcIndustry_EEK.R
+++ b/R/calcIndustry_EEK.R
@@ -2,6 +2,7 @@
 #'
 #' @param kap General internal capital stock, as calculated internally by
 #'   `calcCapital()`.
+#' @param scenarios Vector of strings designating the scenarios to be returned.
 #'
 #' @return A list with a [`magpie`][magclass::magclass] object `x`, `weight`,
 #'   `unit`, and `description` fields.
@@ -12,10 +13,10 @@
 #' @importFrom quitte madrat_mule
 #' @importFrom rlang .data .env sym syms
 #' @importFrom tidyr nest pivot_longer unnest
-#' @importFrom dplyr desc 
-
+#' @importFrom dplyr desc
 #' @export
-calcIndustry_EEK <- function(kap) {
+#'
+calcIndustry_EEK <- function(kap, scenarios) {
   # setup ----
   i <- log(4) / 50    # assuming 50 year lifetime of EEK
   base_year <- 2015
@@ -27,14 +28,19 @@ calcIndustry_EEK <- function(kap) {
   industry_VA <- calcOutput(
     type = 'Industry_Value_Added',
     subtype = 'economic',
+    scenario = unique(c(scenarios, "SSP2")),
     match.steel.historic.values = TRUE,
     match.steel.estimates = 'IEA_ETP',
     China_Production = readSource(type = 'ExpertGuess',
                                   subtype = 'Chinese_Steel_Production',
                                   convert = FALSE) %>%
       madrat_mule(),
-    aggregate = FALSE, years = base_year, supplementary = FALSE, warnNA = FALSE) %>%
-    `[`(,,'SSP2') %>%
+    aggregate = FALSE,
+    years = base_year,
+    supplementary = FALSE,
+    warnNA = FALSE
+  ) %>%
+    mselect(scenario = "SSP2") %>%
     quitte::magclass_to_tibble() %>%
     select('iso3c', subsector = 'name', VA = 'value') %>%
     mutate(subsector = sub('_VA$', '', .data$subsector))
@@ -44,7 +50,7 @@ calcIndustry_EEK <- function(kap) {
     madrat_mule()
 
   ## industry subsector activity and FE projections ----
-  FEdemand <- calcOutput(type = 'FEdemand', aggregate = FALSE, supplementary = FALSE)
+  FEdemand <- calcOutput("FEdemand", scenario = unique(c(scenarios, "SSP2")), aggregate = FALSE)
 
   # calculate EEK ----
   ## split industry VA into IEA investment sectors ----

--- a/R/calcIndustry_Value_Added.R
+++ b/R/calcIndustry_Value_Added.R
@@ -318,7 +318,7 @@ calcIndustry_Value_Added <- function(subtype = 'physical',
              'GDPpC', 'steel.VApt'),
 
     calcOutput(type = 'Steel_Projections',
-               scenario = scenarios,
+               scenarios = scenarios,
                match.steel.historic.values = match.steel.historic.values,
                match.steel.estimates = match.steel.estimates,
                China_Production = China_Production,

--- a/R/calcSteel_Projections.R
+++ b/R/calcSteel_Projections.R
@@ -1230,6 +1230,7 @@ calcSteel_Projections <- function(subtype = 'production',
              as.magpie(spatial = 2, temporal = 3, data = 4),
            weight = calcOutput(
              type = 'Steel_Projections',
+             scenarios = scenarios,
              match.steel.historic.values = match.steel.historic.values,
              match.steel.estimates = match.steel.estimates,
              aggregate = FALSE, years = unique(quitte::remind_timesteps$period),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # input data generation for the REMIND industry module
 
-R package **mrindustry**, version **0.15.1**
+R package **mrindustry**, version **0.16.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrindustry)](https://cran.r-project.org/package=mrindustry) [![R build status](https://github.com/pik-piam/mrindustry/workflows/check/badge.svg)](https://github.com/pik-piam/mrindustry/actions) [![codecov](https://codecov.io/gh/pik-piam/mrindustry/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrindustry) [![r-universe](https://pik-piam.r-universe.dev/badges/mrindustry)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **mrindustry** in publications use:
 
-Benke F, Dürrwächter J, Rodrigues R, Moreno-Leiva S, Baumstark L, Pehl M (2025). "mrindustry: input data generation for the REMIND industry module." Version: 0.15.1, <https://github.com/pik-piam/mrindustry>.
+Benke F, Dürrwächter J, Rodrigues R, Moreno-Leiva S, Baumstark L, Pehl M (2025). "mrindustry: input data generation for the REMIND industry module." Version: 0.16.0, <https://github.com/pik-piam/mrindustry>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,6 +50,6 @@ A BibTeX entry for LaTeX users is
   date = {2025-02-21},
   year = {2025},
   url = {https://github.com/pik-piam/mrindustry},
-  note = {Version: 0.15.1},
+  note = {Version: 0.16.0},
 }
 ```

--- a/inst/extdata/specific_material_relative.csv
+++ b/inst/extdata/specific_material_relative.csv
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 scenario,               base.scenario,   region,   subsector,         factor
 SDP,                    SSP1,            NA,       cement,            1
 SDP,                    SSP1,            NA,       chemicals,         1
@@ -152,13 +151,13 @@ SSP2_highDemDEU,        SSP2,            NA,       chemicals,         1
 SSP2_highDemDEU,        SSP2,            NA,       steel_primary,     1
 SSP2_highDemDEU,        SSP2,            NA,       steel_secondary,   1
 SSP2_highDemDEU,        SSP2,            NA,       otherInd,          1
-SSP2IndiaMedium,        SSP2,            NA,       cement,             1
-SSP2IndiaMedium,        SSP2,            NA,       chemicals,          1
-SSP2IndiaMedium,        SSP2,            NA,       steel_primary,      1
-SSP2IndiaMedium,        SSP2,            NA,       steel_secondary,    1
-SSP2IndiaMedium,        SSP2,            NA,       otherInd,           1
-SSP2IndiaHigh,          SSP2,            NA,       cement,             1
-SSP2IndiaHigh,          SSP2,            NA,       chemicals,          1
-SSP2IndiaHigh,          SSP2,            NA,       steel_primary,      1
-SSP2IndiaHigh,          SSP2,            NA,       steel_secondary,    1
-SSP2IndiaHigh,          SSP2,            NA,       otherInd,           1
+SSP2IndiaMedium,        SSP2,            NA,       cement,            1
+SSP2IndiaMedium,        SSP2,            NA,       chemicals,         1
+SSP2IndiaMedium,        SSP2,            NA,       steel_primary,     1
+SSP2IndiaMedium,        SSP2,            NA,       steel_secondary,   1
+SSP2IndiaMedium,        SSP2,            NA,       otherInd,          1
+SSP2IndiaHigh,          SSP2,            NA,       cement,            1
+SSP2IndiaHigh,          SSP2,            NA,       chemicals,         1
+SSP2IndiaHigh,          SSP2,            NA,       steel_primary,     1
+SSP2IndiaHigh,          SSP2,            NA,       steel_secondary,   1
+SSP2IndiaHigh,          SSP2,            NA,       otherInd,          1

--- a/inst/extdata/specific_material_relative.csv
+++ b/inst/extdata/specific_material_relative.csv
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 scenario,               base.scenario,   region,   subsector,         factor
 SDP,                    SSP1,            NA,       cement,            1
 SDP,                    SSP1,            NA,       chemicals,         1
@@ -151,3 +152,13 @@ SSP2_highDemDEU,        SSP2,            NA,       chemicals,         1
 SSP2_highDemDEU,        SSP2,            NA,       steel_primary,     1
 SSP2_highDemDEU,        SSP2,            NA,       steel_secondary,   1
 SSP2_highDemDEU,        SSP2,            NA,       otherInd,          1
+SSP2IndiaMedium,        SSP2,            NA,       cement,             1
+SSP2IndiaMedium,        SSP2,            NA,       chemicals,          1
+SSP2IndiaMedium,        SSP2,            NA,       steel_primary,      1
+SSP2IndiaMedium,        SSP2,            NA,       steel_secondary,    1
+SSP2IndiaMedium,        SSP2,            NA,       otherInd,           1
+SSP2IndiaHigh,          SSP2,            NA,       cement,             1
+SSP2IndiaHigh,          SSP2,            NA,       chemicals,          1
+SSP2IndiaHigh,          SSP2,            NA,       steel_primary,      1
+SSP2IndiaHigh,          SSP2,            NA,       steel_secondary,    1
+SSP2IndiaHigh,          SSP2,            NA,       otherInd,           1

--- a/man/UNIDO.Rd
+++ b/man/UNIDO.Rd
@@ -6,27 +6,35 @@
 \alias{calcUNIDO}
 \title{UNIDO data}
 \usage{
-readUNIDO(subtype = "INDSTAT2")
+readUNIDO(subtype = "INDSTAT3")
 
-convertUNIDO(x, subtype = "INDSTAT2")
+convertUNIDO(x, subtype = "INDSTAT3", exclude = TRUE)
 
-calcUNIDO(subtype = "INDSTAT2")
+calcUNIDO(subtype = "INDSTAT3")
 }
 \arguments{
 \item{subtype}{one of
-- \code{INDSTAT2}: read INDSTAT2 data}
+- \code{INDSTAT2}: read INDSTAT 2 data
+- \code{INDSTAT3}: read INDSTAT 3 data from \link{https://stat.unido.org/data/download?dataset=indstat&revision=3}
+- \code{INDSTAT4}: read INDSTAT 4 data from \link{https://stat.unido.org/data/download?dataset=indstat&revision=4}
+INDSTAT 4 data quality has not been vetted and should not be used for
+production.}
 
 \item{x}{result from \code{readUNIDO()} as passed to \code{convertUNIDO()}}
+
+\item{exclude}{Exclude faulty data (\code{TRUE}, default) or not.  Return a tibble
+of country/subsector/year combinations for \code{exclude = 'return'}.
+(Work-in-progress)}
 }
 \value{
 A \code{\link[magclass:magclass-package]{magpie}} object.
 
-\code{readUNIDO} returns raw INDSTAT2 data.  \code{convertUNIDO} converts to iso3c
+\code{readUNIDO} returns raw INDSTAT data.  \code{convertUNIDO} converts to iso3c
 country codes, selects industry subsectors value added data according to this
 table\tabular{llll}{
    subsector \tab ISIC \tab ctable \tab utable \cr
    manufacturing \tab D \tab 20 \tab 17–20 \cr
-   cement \tab 20 \tab 20 \tab 17–20 \cr
+   cement \tab 26 \tab 20 \tab 17–20 \cr
    chemicals \tab 24 \tab 20 \tab 17–20 \cr
    steel \tab 27 \tab 20 \tab 17–20 \cr
 }
@@ -37,19 +45,19 @@ regressions according to this table\tabular{lll}{
    subsector \tab iso3c \tab years \cr
    manufacturing \tab BIH \tab 1990–91 \cr
    manufacturing \tab CHN \tab 1963–97 \cr
+   manufacturing \tab EGY \tab 2018-19 \cr
    manufacturing \tab HKG \tab 1963–2015 \cr
-   manufacturing \tab IRQ \tab 1994–98 \cr
    manufacturing \tab MAC \tab 1963–2015 \cr
    manufacturing \tab MDV \tab 1963–2015 \cr
    cement \tab BDI \tab 1980–2010 \cr
    cement \tab CIV \tab 1990–93 \cr
    cement \tab HKG \tab 1973–79 \cr
-   cement \tab IRQ \tab 1992–97 \cr
    cement \tab NAM \tab 2007–10 \cr
    cement \tab RUS \tab 1970–90 \cr
    chemicals \tab CIV \tab 1989 \cr
    chemicals \tab HKG \tab 1973–79, 2008–15 \cr
    chemicals \tab MAC \tab 1978–79 \cr
+   chemicals \tab MMR \tab 2021 \cr
    chemicals \tab NER \tab 1999–2002 \cr
    steel \tab BGD \tab 2011 \cr
    steel \tab CHE \tab 1995–96 \cr
@@ -62,6 +70,10 @@ regressions according to this table\tabular{lll}{
    steel \tab MKD \tab 1996 \cr
    steel \tab PAK \tab 1981–82 \cr
    steel \tab TUN \tab 2003–06 \cr
+   all \tab IRN \tab 2022 \cr
+   all \tab IRQ \tab 1992-2002 \cr
+   all \tab MWI \tab 2021 \cr
+   all \tab TZA \tab 2022 \cr
 }
 
 

--- a/man/calcFeDemandIndustry.Rd
+++ b/man/calcFeDemandIndustry.Rd
@@ -4,9 +4,16 @@
 \alias{calcFeDemandIndustry}
 \title{Calculates FE demand in industry as REMIND variables}
 \usage{
-calcFeDemandIndustry(use_ODYM_RECC = FALSE, last_empirical_year = 2020)
+calcFeDemandIndustry(
+  scenarios,
+  use_ODYM_RECC = FALSE,
+  last_empirical_year = 2020
+)
 }
 \arguments{
+\item{scenarios}{Vector of strings designating the scenario. !!Currently it acts as a filter only, with the actual
+scenarios computed within the function hard-coded into remind_scenarios.}
+
 \item{use_ODYM_RECC}{per-capita pathways for \code{SDP_xx} scenarios?  (Defaults
 to \code{FALSE}.)}
 

--- a/man/calcIndustry_CCS_limits.Rd
+++ b/man/calcIndustry_CCS_limits.Rd
@@ -5,6 +5,7 @@
 \title{Calculate Limits on Industry CCS Capacities}
 \usage{
 calcIndustry_CCS_limits(
+  scenarios,
   a1 = 0.3,
   a2 = 0.15,
   installation_minimum = 1,
@@ -17,6 +18,8 @@ calcIndustry_CCS_limits(
 )
 }
 \arguments{
+\item{scenarios}{Vector of strings designating the FEdemand scenarios.}
+
 \item{a1, a2}{Annual growth factors of CCS capacity limits, for the first ten
 years and thereafter, default to \code{0.7} and \code{0.2} (70 \% and 20 \%,
 respectively).}

--- a/man/calcIndustry_EEK.Rd
+++ b/man/calcIndustry_EEK.Rd
@@ -4,11 +4,13 @@
 \alias{calcIndustry_EEK}
 \title{Industry Energy Efficiency Capital}
 \usage{
-calcIndustry_EEK(kap)
+calcIndustry_EEK(kap, scenarios)
 }
 \arguments{
 \item{kap}{General internal capital stock, as calculated internally by
 `calcCapital()`.}
+
+\item{scenarios}{Vector of strings designating the scenarios to be returned.}
 }
 \value{
 A list with a [`magpie`][magclass::magclass] object `x`, `weight`,

--- a/man/calcIndustry_Value_Added.Rd
+++ b/man/calcIndustry_Value_Added.Rd
@@ -6,10 +6,12 @@
 \usage{
 calcIndustry_Value_Added(
   subtype = "physical",
+  scenarios,
   match.steel.historic.values = TRUE,
   match.steel.estimates = "none",
   save.plots = NULL,
-  China_Production = NULL
+  China_Production = NULL,
+  INDSTAT = "INDSTAT3"
 )
 }
 \arguments{
@@ -18,6 +20,8 @@ calcIndustry_Value_Added(
 \item \code{physical} Returns physical production trajectories for cement.
 \item \code{economic} Returns value added trajectories for all subsectors.
 }}
+
+\item{scenarios}{Vector of strings designating the scenarios to be returned.}
 
 \item{match.steel.historic.values}{Should steel production trajectories match
 historic values?}
@@ -36,6 +40,8 @@ directories to.}
 \item{China_Production}{A data frame with columns \code{period} and
 \code{total.production} prescribing total production for China to have,
 disregarding results from the stock saturation model.}
+
+\item{INDSTAT}{Gets passed to \code{\link[=readUNIDO]{readUNIDO()}} as \code{subtype} argument.}
 }
 \value{
 A list with a \code{\link[magclass:magclass-package]{magpie}} object \code{x}, \code{weight},

--- a/man/calcSteel_Projections.Rd
+++ b/man/calcSteel_Projections.Rd
@@ -6,6 +6,7 @@
 \usage{
 calcSteel_Projections(
   subtype = "production",
+  scenarios,
   match.steel.historic.values = TRUE,
   match.steel.estimates = "none",
   save.plots = NULL,
@@ -20,6 +21,8 @@ production.
 \item \code{secondary.steel.max.share} Returns the maximum share of secondary steel
 in total steel production.
 }}
+
+\item{scenarios}{Vector of strings designating the scenarios to be returned.}
 
 \item{match.steel.historic.values}{Should steel production trajectories match
 historic values?}


### PR DESCRIPTION
- Introduce a scenario argument to calcFeDemandIndustry, calcIndustry_EEK and calcIndustry_Value_Added. The larger picture is the attempt to step away from a default set of scenarios. The choice of scenarios should be explicit. In the case of the input data pipeline, it is made in fullREMIND and then passed on to the different calcOutput functions. Hopefully this will help us control/drop/introduce new scenarios more easily in the future.
- Add placeholder assumptions in inst data for the SSP2IndiaDEA scenarios.
- Move SSP2_NAV_all duplication over from mrremind.
