### PR TITLE
remove calculation of stationary data

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3688731'
+ValidationKey: '3829830'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3709440'
+ValidationKey: '3729600'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrindustry: input data generation for the REMIND industry module'
-version: 0.18.3
+version: 0.19.0
 date-released: '2025-03-10'
 abstract: The mrindustry packages contains data preprocessing for the REMIND model.
 authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrindustry: input data generation for the REMIND industry module'
-version: 0.18.4
+version: 0.18.5
 date-released: '2025-03-13'
 abstract: The mrindustry packages contains data preprocessing for the REMIND model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrindustry
 Title: input data generation for the REMIND industry module
-Version: 0.18.4
+Version: 0.18.5
 Date: 2025-03-13
 Authors@R: c(
     person(given = "Falk", family = "Benke", email = "benke@pik-potsdam.de",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrindustry
 Title: input data generation for the REMIND industry module
-Version: 0.18.3
+Version: 0.19.0
 Date: 2025-03-10
 Authors@R: c(
     person(given = "Falk", family = "Benke", email = "benke@pik-potsdam.de",

--- a/R/calcFeDemandIndustry.R
+++ b/R/calcFeDemandIndustry.R
@@ -47,131 +47,6 @@ calcFeDemandIndustry <- function(scenarios, use_ODYM_RECC = FALSE, last_empirica
     remind_scenarios %in% mrdrivers::toolGetScenarioDefinition(driver = "GDPpc", aslist = TRUE)$scenario
   ]
 
-  # ---- Industry subsectors data and FE stubs ----
-  stationary <- readSource("Stationary", subset = remind_scenarios)[, , c("feindheat", "feh2i")]
-
-  # aggregate to 5-year averages to suppress volatility
-  stationary <- mrremind::toolAggregateTimeSteps(stationary)
-
-  modified <- stationary %>%
-    as.quitte() %>%
-    as_tibble() %>%
-    select("scenario", "iso3c" = "region", "pf" = "item", "year" = "period",
-           "value") %>%
-    character.data.frame()
-
-  regionmapping <- toolGetMapping(type = "regional",
-                                  name = "regionmappingH12.csv", where = "mappingfolder") %>%
-    select(country = "X", iso3c = "CountryCode", region = "RegionCode")
-
-  historic_trend <- c(2004, 2020)
-  phasein_period <- c(2020, 2050)   # FIXME: extend to 2055 to keep 35 yrs?
-  phasein_time   <- phasein_period[2] - phasein_period[1]
-
-  modified <- bind_rows(
-    modified %>%
-      filter(phasein_period[1] > !!sym("year")),
-    inner_join(
-      # calculate regional trend
-      modified %>%
-        # get trend period
-        filter(between(!!sym("year"), historic_trend[1], historic_trend[2]),
-               0 != !!sym("value")) %>%
-        # sum regional totals
-        full_join(regionmapping %>% select(-!!sym("country")), "iso3c") %>%
-        group_by(!!sym("scenario"), !!sym("region"), !!sym("pf"),
-                 !!sym("year")) %>%
-        summarise(value = sum(!!sym("value")), .groups = "drop") %>%
-        # calculate average trend over trend period
-        interpolate_missing_periods(year = seq_range(historic_trend), expand.values = TRUE) %>%
-        group_by(!!sym("scenario"), !!sym("region"), !!sym("pf")) %>%
-        summarise(trend = mean(!!sym("value") / lag(!!sym("value")),
-                               na.rm = TRUE),
-                  .groups = "drop") %>%
-        # only use negative trends (decreasing energy use)
-        mutate(trend = ifelse(!!sym("trend") < 1, !!sym("trend"), NA)),
-      # modify data projection
-      modified %>%
-        filter(phasein_period[1] <= !!sym("year")) %>%
-        interpolate_missing_periods(year = phasein_period[1]:max(modified$year)) %>%
-        group_by(!!sym("scenario"), !!sym("iso3c"), !!sym("pf")) %>%
-        mutate(growth = replace_na(!!sym("value") / lag(!!sym("value")), 1)) %>%
-        full_join(regionmapping %>% select(-"country"), "iso3c"),
-      c("scenario", "region", "pf")) %>%
-      group_by(!!sym("scenario"), !!sym("iso3c"), !!sym("pf")) %>%
-      mutate(
-        # replace NA (positive) trends with end. growth rates -> no change
-        trend = ifelse(is.na(!!sym("trend")), !!sym("growth"), !!sym("trend")),
-        value_ = first(!!sym("value"))
-        * cumprod(
-          ifelse(
-            phasein_period[1] == !!sym("year"), 1,
-            (!!sym("trend")
-             * pmax(0, phasein_period[2] - !!sym("year") + 1)
-             + !!sym("growth")
-             * pmin(phasein_time, !!sym("year") - phasein_period[1] - 1)
-            ) / phasein_time)),
-        value = ifelse(is.na(!!sym("value_")) | 0 == !!sym("value_"),
-                       !!sym("value"), !!sym("value_"))) %>%
-      ungroup() %>%
-      select(-"region", -"value_", -"trend", -"growth") %>%
-      filter(!!sym("year") %in% unique(modified$year))
-  ) %>%
-    rename("region" = "iso3c", "item" = "pf") %>%
-    as.magpie()
-
-  # ---- _ modify SSP1 Industry FE demand ----
-  # compute a reduction factor of 1 before 2021, 0.84 in 2050, and increasing
-  # to 0.78 in 2150
-  y <- getYears(stationary, as.integer = TRUE)
-  f <- y - 2020
-  f[f < 0] <- 0
-  f <- 0.95^pmax(0, log(f))
-
-  # get Industry FE items
-  v <- grep("^SSP1\\.fe(..i$|ind)", getNames(modified), value = TRUE)
-
-  # apply changes
-  for (i in 1:length(y)) {
-    if (1 != f[i]) {
-      modified[, y[i], v] <- modified[, y[i], v] * f[i]
-    }
-  }
-
-  # ---- _ map to REMIND variables ----
-
-  data <- modified
-
-  mapping <- toolGetMapping(type = "sectoral", name = "structuremappingIO_outputs.csv",
-                            where = "mrcommons")
-  mapping <- mapping %>%
-    select("EDGEitems", "REMINDitems_out", "weight_Fedemand") %>%
-    na.omit() %>%
-    filter(.data$EDGEitems %in% getNames(data, dim = "item")) %>%
-    # REMIND variables in focus: stationary items with industry focus
-    filter(grepl("s$", .data$REMINDitems_out) & grepl("fe(..i$|ind)", .data$EDGEitems)) %>%
-    distinct()
-
-  remind <- new.magpie(cells_and_regions = getItems(data, dim = 1),
-                       years = getYears(data),
-                       names = cartesian(getNames(data, dim = "scenario"), unique(mapping$REMINDitems_out)),
-                       sets = getSets(data))
-
-  for (v in unique(mapping$REMINDitems_out)) {
-
-    w <- mapping %>%
-      filter(.data$REMINDitems_out == v) %>%
-      select(-"REMINDitems_out") %>%
-      as.magpie()
-
-    tmp <- mselect(data, item = getNames(w)) * w
-
-    tmp <- dimSums(tmp, dim = "item", na.rm = TRUE) %>%
-      add_dimension(dim = 3.3, add = "item", nm = v)
-
-    remind[, , getNames(tmp)] <- tmp
-  }
-
   remind_years <- seq(1995, 2150, 5)
 
   # ---- Industry subsectors data and FE stubs ----
@@ -1415,7 +1290,6 @@ calcFeDemandIndustry <- function(scenarios, use_ODYM_RECC = FALSE, last_empirica
 
 
   remind <- mbind(
-    remind,
     industry_subsectors_en[,remind_years,],
     industry_subsectors_ue[,remind_years,])
 

--- a/R/calcIndustry_CCS_limits.R
+++ b/R/calcIndustry_CCS_limits.R
@@ -90,14 +90,15 @@ calcIndustry_CCS_limits <- function(
 
   ## read SSP2 industry activity ----
   ### Pass the scenarios argument to FEdemand to optimize madrat caching.
-  ind_activity <- calcOutput("FEdemand",
-                             scenario = unique(c(scenarios, "SSP2")),
+  ind_activity <- calcOutput("FeDemandIndustry",
+                             scenarios = unique(c(scenarios, "SSP2")),
+                             warnNA = FALSE,
                              aggregate = FALSE,
                              years = remind_timesteps) %>%
     `[`(,,paste0('SSP2.', c('ue_cement', 'ue_chemicals', 'ue_steel_primary'))) %>%
     magclass_to_tibble() %>%
     mutate(subsector = sub('ue_([^_]+).*', '\\1', .data$item), .keep = 'unused') %>%
-    select(iso3c = 'region', 'subsector', period= 'year',  activity = 'value')
+    select(iso3c = 'region', 'subsector', period = 'year',  activity = 'value')
 
   ## set/check region mapping ----
   iso3c_list <- read_delim(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # input data generation for the REMIND industry module
 
-R package **mrindustry**, version **0.18.4**
+R package **mrindustry**, version **0.18.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrindustry)](https://cran.r-project.org/package=mrindustry) [![R build status](https://github.com/pik-piam/mrindustry/workflows/check/badge.svg)](https://github.com/pik-piam/mrindustry/actions) [![codecov](https://codecov.io/gh/pik-piam/mrindustry/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrindustry) [![r-universe](https://pik-piam.r-universe.dev/badges/mrindustry)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **mrindustry** in publications use:
 
-Benke F, Dürrwächter J, Rodrigues R, Moreno-Leiva S, Baumstark L, Pehl M, Weiss B (2025). "mrindustry: input data generation for the REMIND industry module." Version: 0.18.4, <https://github.com/pik-piam/mrindustry>.
+Benke F, Dürrwächter J, Rodrigues R, Moreno-Leiva S, Baumstark L, Pehl M, Weiss B (2025). "mrindustry: input data generation for the REMIND industry module." Version: 0.18.5, <https://github.com/pik-piam/mrindustry>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,6 +50,6 @@ A BibTeX entry for LaTeX users is
   date = {2025-03-13},
   year = {2025},
   url = {https://github.com/pik-piam/mrindustry},
-  note = {Version: 0.18.4},
+  note = {Version: 0.18.5},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # input data generation for the REMIND industry module
 
-R package **mrindustry**, version **0.18.3**
+R package **mrindustry**, version **0.19.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrindustry)](https://cran.r-project.org/package=mrindustry) [![R build status](https://github.com/pik-piam/mrindustry/workflows/check/badge.svg)](https://github.com/pik-piam/mrindustry/actions) [![codecov](https://codecov.io/gh/pik-piam/mrindustry/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrindustry) [![r-universe](https://pik-piam.r-universe.dev/badges/mrindustry)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **mrindustry** in publications use:
 
-Benke F, Dürrwächter J, Rodrigues R, Moreno-Leiva S, Baumstark L, Pehl M, Weiss B (2025). "mrindustry: input data generation for the REMIND industry module." Version: 0.18.3, <https://github.com/pik-piam/mrindustry>.
+Benke F, Dürrwächter J, Rodrigues R, Moreno-Leiva S, Baumstark L, Pehl M, Weiss B (2025). "mrindustry: input data generation for the REMIND industry module." Version: 0.19.0, <https://github.com/pik-piam/mrindustry>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,6 +50,6 @@ A BibTeX entry for LaTeX users is
   date = {2025-03-10},
   year = {2025},
   url = {https://github.com/pik-piam/mrindustry},
-  note = {Version: 0.18.3},
+  note = {Version: 0.19.0},
 }
 ```


### PR DESCRIPTION
With https://github.com/pik-piam/mrremind/pull/644, we no longer need stationary data, so this PR removes it from calcFeDemandIndustry