### PR TITLE
directly call calcFeDemandIndustry in calcIndustry_CCS_limits

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3688731'
+ValidationKey: '3709440'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrindustry: input data generation for the REMIND industry module'
-version: 0.18.3
-date-released: '2025-03-10'
+version: 0.18.4
+date-released: '2025-03-13'
 abstract: The mrindustry packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrindustry
 Title: input data generation for the REMIND industry module
-Version: 0.18.3
-Date: 2025-03-10
+Version: 0.18.4
+Date: 2025-03-13
 Authors@R: c(
     person(given = "Falk", family = "Benke", email = "benke@pik-potsdam.de",
            role = c("aut", "cre")),

--- a/R/calcIndustry_CCS_limits.R
+++ b/R/calcIndustry_CCS_limits.R
@@ -89,15 +89,16 @@ calcIndustry_CCS_limits <- function(
   remind_timesteps <- unique(quitte::remind_timesteps$period)
 
   ## read SSP2 industry activity ----
-  ### Pass the scenarios argument to FEdemand to optimize madrat caching.
-  ind_activity <- calcOutput("FEdemand",
-                             scenario = unique(c(scenarios, "SSP2")),
+  ### Pass the scenarios argument to FeDemandIndustry to optimize madrat caching.
+  ind_activity <- calcOutput("FeDemandIndustry",
+                             scenarios = unique(c(scenarios, "SSP2")),
+                             warnNA = FALSE,
                              aggregate = FALSE,
                              years = remind_timesteps) %>%
     `[`(,,paste0('SSP2.', c('ue_cement', 'ue_chemicals', 'ue_steel_primary'))) %>%
     magclass_to_tibble() %>%
     mutate(subsector = sub('ue_([^_]+).*', '\\1', .data$item), .keep = 'unused') %>%
-    select(iso3c = 'region', 'subsector', period= 'year',  activity = 'value')
+    select(iso3c = 'region', 'subsector', period = 'year',  activity = 'value')
 
   ## set/check region mapping ----
   iso3c_list <- read_delim(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # input data generation for the REMIND industry module
 
-R package **mrindustry**, version **0.18.3**
+R package **mrindustry**, version **0.18.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrindustry)](https://cran.r-project.org/package=mrindustry) [![R build status](https://github.com/pik-piam/mrindustry/workflows/check/badge.svg)](https://github.com/pik-piam/mrindustry/actions) [![codecov](https://codecov.io/gh/pik-piam/mrindustry/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrindustry) [![r-universe](https://pik-piam.r-universe.dev/badges/mrindustry)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **mrindustry** in publications use:
 
-Benke F, Dürrwächter J, Rodrigues R, Moreno-Leiva S, Baumstark L, Pehl M, Weiss B (2025). "mrindustry: input data generation for the REMIND industry module." Version: 0.18.3, <https://github.com/pik-piam/mrindustry>.
+Benke F, Dürrwächter J, Rodrigues R, Moreno-Leiva S, Baumstark L, Pehl M, Weiss B (2025). "mrindustry: input data generation for the REMIND industry module." Version: 0.18.4, <https://github.com/pik-piam/mrindustry>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrindustry: input data generation for the REMIND industry module},
   author = {Falk Benke and Jakob Dürrwächter and Renato Rodrigues and Simón Moreno-Leiva and Lavinia Baumstark and Michaja Pehl and Bennet Weiss},
-  date = {2025-03-10},
+  date = {2025-03-13},
   year = {2025},
   url = {https://github.com/pik-piam/mrindustry},
-  note = {Version: 0.18.3},
+  note = {Version: 0.18.4},
 }
 ```


### PR DESCRIPTION
This fixes a bug in current inputdata generation due due to a refactoring of calcFEdemand, but also avoids running unnecessary buildings calculations.