### PR TITLE
update reading in UNFCCC data in calcEmissionFactorsFeedstocks

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4897112'
+ValidationKey: '4927797'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrindustry: input data generation for the REMIND industry module'
-version: 0.24.2
-date-released: '2025-05-28'
+version: 0.24.3
+date-released: '2025-07-10'
 abstract: The mrindustry packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrindustry
 Title: input data generation for the REMIND industry module
-Version: 0.24.2
-Date: 2025-05-28
+Version: 0.24.3
+Date: 2025-07-10
 Authors@R: c(
     person(given = "Falk", family = "Benke", email = "benke@pik-potsdam.de",
            role = c("aut", "cre")),

--- a/R/calcEmissionFactorsFeedstocks.R
+++ b/R/calcEmissionFactorsFeedstocks.R
@@ -28,7 +28,7 @@ calcEmissionFactorsFeedstocks <- function() {
   iea <- iea[!remove, , ]
 
   # read in emissions from UNFCCC and convert from kt CO2 to GtC
-  emi <- readSource("UNFCCC", convert = F)[, , "Table2(I)s1|Total industrial processes|Chemical industry|CO2.kt CO2"] * 1e-6 / 3.666666666667
+  emi <- readSource("UNFCCC", convert = F)[, , "2_B_ Chemical industry|CO2"] * 1e-6 / 3.666666666667
   remove <- magpply(emi, function(y) all(is.na(y)), MARGIN = 1)
   emi <- emi[!remove, , ]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # input data generation for the REMIND industry module
 
-R package **mrindustry**, version **0.24.2**
+R package **mrindustry**, version **0.24.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrindustry)](https://cran.r-project.org/package=mrindustry) [![R build status](https://github.com/pik-piam/mrindustry/workflows/check/badge.svg)](https://github.com/pik-piam/mrindustry/actions) [![codecov](https://codecov.io/gh/pik-piam/mrindustry/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrindustry) [![r-universe](https://pik-piam.r-universe.dev/badges/mrindustry)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **mrindustry** in publications use:
 
-Benke F, Dürrwächter J, Rodrigues R, Moreno-Leiva S, Baumstark L, Pehl M, Weiss B (2025). "mrindustry: input data generation for the REMIND industry module." Version: 0.24.2, <https://github.com/pik-piam/mrindustry>.
+Benke F, Dürrwächter J, Rodrigues R, Moreno-Leiva S, Baumstark L, Pehl M, Weiss B (2025). "mrindustry: input data generation for the REMIND industry module." Version: 0.24.3, <https://github.com/pik-piam/mrindustry>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrindustry: input data generation for the REMIND industry module},
   author = {Falk Benke and Jakob Dürrwächter and Renato Rodrigues and Simón Moreno-Leiva and Lavinia Baumstark and Michaja Pehl and Bennet Weiss},
-  date = {2025-05-28},
+  date = {2025-07-10},
   year = {2025},
   url = {https://github.com/pik-piam/mrindustry},
-  note = {Version: 0.24.2},
+  note = {Version: 0.24.3},
 }
 ```


### PR DESCRIPTION
This updates references to UNFCCC data after update to the latest 2024 data. See also https://github.com/pik-piam/mrremind/pull/700/files

It affects the emission factors used in REMIND ( `f_nechem_emissionFactors.cs4r`), as the calculations use UNFCCC data https://github.com/pik-piam/mrindustry/blob/main/R/calcEmissionFactorsFeedstocks.R#L31

![image](https://github.com/user-attachments/assets/58d12c8c-4cb0-4984-9f07-e16be0a88d9f)
![image](https://github.com/user-attachments/assets/c03b6c0c-35ea-4dd9-98ba-67afbcd8bbfd)
![image](https://github.com/user-attachments/assets/86573a4c-626d-42f4-b3ef-2e2ed7a8de07)
