### PR TITLE
Update max secondary steel share to 0.7

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2357730'
+ValidationKey: '2387860'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
@@ -11,3 +11,4 @@ allowLinterWarnings: yes
 enforceVersionUpdate: yes
 skipCoverage: no
 AutocreateCITATION: yes
+UsePkgDown: no

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrindustry: input data generation for the REMIND industry module'
-version: 1.1.5
-date-released: '2026-02-18'
+version: 1.1.6
+date-released: '2026-05-12'
 abstract: The mrindustry packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrindustry
 Title: input data generation for the REMIND industry module
-Version: 1.1.5
-Date: 2026-02-18
+Version: 1.1.6
+Date: 2026-05-12
 Authors@R: c(
     person(given = "Falk", family = "Benke", email = "benke@pik-potsdam.de",
            role = c("aut", "cre")),

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # input data generation for the REMIND industry module
 
-R package **mrindustry**, version **1.1.5**
+R package **mrindustry**, version **1.1.6**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/mrindustry)](https://cran.r-project.org/package=mrindustry) [![R build status](https://github.com/pik-piam/mrindustry/workflows/check/badge.svg)](https://github.com/pik-piam/mrindustry/actions) [![codecov](https://codecov.io/gh/pik-piam/mrindustry/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrindustry) [![r-universe](https://pik-piam.r-universe.dev/badges/mrindustry)](https://pik-piam.r-universe.dev/builds)
+   [![R build status](https://github.com/pik-piam/mrindustry/workflows/check/badge.svg)](https://github.com/pik-piam/mrindustry/actions) [![codecov](https://codecov.io/gh/pik-piam/mrindustry/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrindustry) [![r-universe](https://pik-piam.r-universe.dev/badges/mrindustry)](https://pik-piam.r-universe.dev/builds)
 
 ## Purpose and Functionality
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **mrindustry** in publications use:
 
-Benke F, Dürrwächter J, Rodrigues R, Moreno-Leiva S, Baumstark L, Pehl M, Weiss B (2026). "mrindustry: input data generation for the REMIND industry module." Version: 1.1.5, <https://github.com/pik-piam/mrindustry>.
+Benke F, Dürrwächter J, Rodrigues R, Moreno-Leiva S, Baumstark L, Pehl M, Weiss B (2026). "mrindustry: input data generation for the REMIND industry module." Version: 1.1.6, <https://github.com/pik-piam/mrindustry>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrindustry: input data generation for the REMIND industry module},
   author = {Falk Benke and Jakob Dürrwächter and Renato Rodrigues and Simón Moreno-Leiva and Lavinia Baumstark and Michaja Pehl and Bennet Weiss},
-  date = {2026-02-18},
+  date = {2026-05-12},
   year = {2026},
   url = {https://github.com/pik-piam/mrindustry},
-  note = {Version: 1.1.5},
+  note = {Version: 1.1.6},
 }
 ```

--- a/inst/extdata/industry_max_secondary_steel_share.csv
+++ b/inst/extdata/industry_max_secondary_steel_share.csv
@@ -3,5 +3,5 @@
 # apply to all scenarios/regions and are overwritten by specific entries.
 # Regions are from the 21_EU11 mapping.
 scenario,region,from,by,target
-NA,NA,2015,2050,0.9
+NA,NA,2015,2050,0.7
 SSP2EU,DEU,2015,2100,0.81


### PR DESCRIPTION
Related to this issue: https://github.com/remindmodel/development_issues/issues/727

Update max secondary steel share fraction to 0.7 (from 0.9). 70% is the currently observed share of secondary steel in the US[1]. With improved recycling and collection practices, this could still increase - but 70% is a sensible estimate today given current constraints [2].

[1] Bailey, S., Lockwood, T. & Wakim, G. Decarbonization Pathways and Policy Recommendations for the United States Steel Sector. https://www.catf.us/resource/decarbonization-pathways-policy-recommendations-united-states-steel-sector/ (2025). 

[2] Li, F. G. N. et al. Technology and policy options for achieving net zero steel manufacturing in the United States. Energy Policy 211, 115124 (2026). 